### PR TITLE
Add VAX brb.bin test binary for brb instruction

### DIFF
--- a/vax/brb.bin
+++ b/vax/brb.bin
@@ -1,0 +1,1 @@
+echo -ne '\x11\x00' > ../bin/vax/brb.bin


### PR DESCRIPTION
Adds `brb.bin`, a test binary for the VAX `brb` instruction (e.g., 0x11 0x05), to support the VAX disassembler plugin in Rizin.
Related to: https://github.com/rizinorg/rizin/pull/5051